### PR TITLE
Introduce session key

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -52,30 +52,50 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
+  packages = [
+    "pbkdf2",
+    "ssh/terminal"
+  ]
   revision = "9f005a07e0d31d45e6656d241bb5c0f2efd4bc94"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp"]
+  packages = [
+    "context",
+    "context/ctxhttp"
+  ]
   revision = "a337091b0525af65de94df2eb7e98bd9962dcbe2"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/oauth2"
-  packages = [".","internal"]
+  packages = [
+    ".",
+    "internal"
+  ]
   revision = "9ff8ebcc8e241d46f52ecc5bff0e5a2f2dbef402"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "bf42f188b9bc6f2cf5b8ee5a912ef1aedd0eba4c"
 
 [[projects]]
   name = "google.golang.org/appengine"
-  packages = ["internal","internal/base","internal/datastore","internal/log","internal/remote_api","internal/urlfetch","urlfetch"]
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch"
+  ]
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
@@ -88,6 +108,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "fa5d4bd42d9d25f94a38747d629035f7996f6751bf2ac7dc770784439e4bfc68"
+  inputs-digest = "1b9b53e6bfb358721513cf7f872f32515a04bc77120f634b99ac09f424adfa7c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,3 +32,7 @@
 [[constraint]]
   branch = "master"
   name = "golang.org/x/oauth2"
+
+[[constraint]]
+  branch = "master"
+  name = "golang.org/x/crypto"

--- a/cmd/gangway/config.go
+++ b/cmd/gangway/config.go
@@ -42,6 +42,8 @@ type Config struct {
 	KeyFile       string   `yaml:"keyFile" envconfig:"key_file"`
 	APIServerURL  string   `yaml:"apiServerURL" envconfig:"apiserver_url"`
 	ClusterCAPath string   `yaml:"clusterCAPath" envconfig:"cluster_ca_path"`
+
+	SessionSecurityKey string `yaml:"sessionSecurityKey" envconfig:"SESSION_SECURITY_KEY"`
 }
 
 // NewConfig returns a Config struct from serialized config file
@@ -93,6 +95,7 @@ func validateConfig(cfg *Config) error {
 		{cfg.ClientID == "", "no clientID specified"},
 		{cfg.ClientSecret == "", "no clientSecret specified"},
 		{cfg.RedirectURL == "", "no redirectURL specified"},
+		{cfg.SessionSecurityKey == "", "no SessionSecurityKey specified"},
 	}
 
 	for _, check := range checks {

--- a/cmd/gangway/session.go
+++ b/cmd/gangway/session.go
@@ -15,27 +15,26 @@
 package main
 
 import (
-	"encoding/base64"
-	"math/rand"
+	"crypto/sha256"
 	"net/http"
-	"time"
+
+	"golang.org/x/crypto/pbkdf2"
 
 	"github.com/gorilla/sessions"
 )
 
-func generateRandomString(length int) string {
-	// seed the random number generator
-	rand.Seed(time.Now().UnixNano())
-
-	b := make([]byte, length)
-	rand.Read(b)
-	randomStr := base64.StdEncoding.EncodeToString(b)
-	return randomStr
-}
+const salt = "MkmfuPNHnZBBivy0L0aW"
 
 func initSessionStore() {
-	secret := generateRandomString(48)
-	sessionStore = sessions.NewCookieStore([]byte(secret))
+	// Take the configured security key and generate 96 bytes of data. This is
+	// used as the signing and encryption keys for the cookie store.  For details
+	// on the PBKDF2 function: https://en.wikipedia.org/wiki/PBKDF2
+	b := pbkdf2.Key(
+		[]byte(cfg.SessionSecurityKey),
+		[]byte(salt),
+		4096, 96, sha256.New)
+
+	sessionStore = sessions.NewCookieStore(b[0:64], b[64:96])
 }
 
 func cleanupSession(w http.ResponseWriter, r *http.Request) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,14 @@ While this is called a secret, based on the way that OAuth2 works with command l
 This will be divulged to any client that is configured through gangway.
 As such, it is probably acceptable to keep that secret in the config file and not worry about managing it as a true secret.
 
+We also have a secret string that is used to as a way to encrypt the cookies that are returned to the users.
+If using the example YAML, create a secret to hold this value with the following command line:
+
+```
+kubectl -n gangway create secret generic gangway-key \
+  --from-literal=sesssionkey=$(openssl rand -base64 32)
+```
+
 ## Docker image
 
 A recent release of Gangway is available at
@@ -101,6 +109,13 @@ apiServerURL: "mycluster.example.com"
 # a Kubernetes cluster and doesn't need to be set.
 # Env var: GANGWAY_CLUSTER_CA_PATH
 # cluster_ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+# This is a string that you must set to a random value. This is used to derive
+# encryption keys for writing cookies to clients.  While you can specify this
+# as a config file, it is probably better to create a secret and inject it
+# with an environment variable.
+# Env var: GANGWAY_SESSION_SECURITY_KEY
+sessionSecurityKey: "<random string>"
 ```
 
 A starting point for this config embedded in a configmap is at [yaml/02-config.yaml].

--- a/docs/yaml/03-deployment.yaml
+++ b/docs/yaml/03-deployment.yaml
@@ -22,6 +22,12 @@ spec:
           image: gcr.io/heptio-images/gangway:latest
           imagePullPolicy: Always
           command: ["gangway", "-config", "/gangway/gangway.yaml"]
+          env:
+            - name: GANGWAY_SESSION_SECURITY_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: gangway-key
+                  key: sesssionkey
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
Fixes #16.

This introduces a new config param that lets users specify a session key.  We instruct them to use a random value and put it in a secret.

We use the pbkdf2 to generate 96 bits of random value from that key.  We now set both the signing and encryption keys on the secure session library so that users can't extract the refresh token from the browser cache.

The one down side here is that this is a new required parameter.  This is unfortunate.  But I feel that it is better to fail vs. having an insecure setup.

It might be good to have gangway create a random value and write it into a secret on first start (and then read from that) but that would mean bringing in client-go and ain't nobody got time for that.