### PR TITLE
main.go: do not log configuration at startup

### DIFF
--- a/cmd/gangway/main.go
+++ b/cmd/gangway/main.go
@@ -54,8 +54,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	log.WithField("config", cfg).Info("active config")
-
 	oauth2Cfg = &oauth2.Config{
 		ClientID:     cfg.ClientID,
 		ClientSecret: cfg.ClientSecret,


### PR DESCRIPTION
Stop logging the configuration at startup, as the configuration includes
secrets.

Fixes #44 