### PR TITLE
Trusted CA

### DIFF
--- a/cmd/gangway/bindata.go
+++ b/cmd/gangway/bindata.go
@@ -193,7 +193,7 @@ var _escData = map[string]*_escFile{
 	"/templates/commandline.tmpl": {
 		local:   "templates/commandline.tmpl",
 		size:    4187,
-		modtime: 1531428210,
+		modtime: 1536697541,
 		compressed: `
 H4sIAAAAAAAC/7RY61fbuBL/zl8x6+052x6qKFBe7Y1zTxqgTQsNJaEUzn5YWZ7YIrJkJDkPevnf75ET
 8wiBcu92v8RoRjO/+c3Dkmn8tttt98+O9iB1mWyuNPwDJFNJGKAKvABZ3FwBaGToGKTO5QQvCzEKg7ZW
@@ -228,7 +228,7 @@ d4uDd+dAbNDZFapBZ/9K+G8AAAD///UTb8hbEAAA
 	"/templates/home.tmpl": {
 		local:   "templates/home.tmpl",
 		size:    2088,
-		modtime: 1531422938,
+		modtime: 1536697541,
 		compressed: `
 H4sIAAAAAAAC/4xWUW/jNgx+76/g6V42LLKbuxXYcnaGrd2AYnfrgHYH7JGWGZutLPkkOW5u2H8fJMdJ
 mhuwBUgsUhT5kR9ppXh1c3f98OfvP0MbOr2+KOIDNJqmFGREVBDW6wuAoqOA0IbQS/o08LYU19YEMkE+

--- a/cmd/gangway/config.go
+++ b/cmd/gangway/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	KeyFile       string   `yaml:"keyFile" envconfig:"key_file"`
 	APIServerURL  string   `yaml:"apiServerURL" envconfig:"apiserver_url"`
 	ClusterCAPath string   `yaml:"clusterCAPath" envconfig:"cluster_ca_path"`
+	TrustedCAPath string   `yaml:"trustedCAPath" envconfig:"trusted_ca_path"`
 
 	SessionSecurityKey string `yaml:"sessionSecurityKey" envconfig:"SESSION_SECURITY_KEY"`
 }

--- a/cmd/gangway/handlers.go
+++ b/cmd/gangway/handlers.go
@@ -115,6 +115,7 @@ func logoutHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func callbackHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := context.WithValue(r.Context(), oauth2.HTTPClient, httpClient)
 
 	// verify the state string
 	state := r.URL.Query().Get("state")
@@ -131,7 +132,7 @@ func callbackHandler(w http.ResponseWriter, r *http.Request) {
 
 	// use the access code to retrieve a token
 	code := r.URL.Query().Get("code")
-	token, err := oauth2Cfg.Exchange(context.TODO(), code)
+	token, err := oauth2Cfg.Exchange(ctx, code)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/cmd/gangway/main.go
+++ b/cmd/gangway/main.go
@@ -62,8 +62,8 @@ func main() {
 		RedirectURL:  cfg.RedirectURL,
 		Scopes:       cfg.Scopes,
 		Endpoint: oauth2.Endpoint{
-			cfg.AuthorizeURL,
-			cfg.TokenURL,
+			AuthURL:  cfg.AuthorizeURL,
+			TokenURL: cfg.TokenURL,
 		},
 	}
 


### PR DESCRIPTION
Allows Gangway to communicate over HTTPS with a service secured using a private CA.