### PR TITLE
Enable travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+go_import_path: github.com/heptiolabs/gangway
+go:
+  - 1.10.x
+
+sudo: false
+
+install:
+  - make setup && make deps
+
+script:
+  - make check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 All authors to the project retain copyright to their work. However, to ensure
 that they are only submitting work that they have rights to, we are requiring
-everyone to acknowldge this by signing their work.
+everyone to acknowledge this by signing their work.
 
 Any copyright notices in this repos should specify the authors as "The
 heptio/gangway authors".

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ PROJECT := gangway
 # Where to push the docker image.
 REGISTRY ?= gcr.io/heptio-images
 IMAGE := $(REGISTRY)/$(PROJECT)
+SRCDIRS := ./cmd/gangway
 
 VERSION ?= master
 
@@ -26,14 +27,39 @@ setup:
 	go get -u github.com/golang/dep/cmd/dep
 	go get -u github.com/mjibson/esc/...
 
+check: test vet gofmt staticcheck unused misspell
+
 deps:
 	dep ensure -v
+
+vet: | test
+	go vet ./...
 
 bindata:
 	esc -o cmd/gangway/bindata.go templates/
 
 test:
 	go test -v ./...
+
+staticcheck:
+	@go get honnef.co/go/tools/cmd/staticcheck
+	staticcheck $(PKGS)
+
+unused:
+	@go get honnef.co/go/tools/cmd/unused
+	unused -exported $(PKGS)
+
+misspell:
+	@go get github.com/client9/misspell/cmd/misspell
+	misspell \
+		-i clas \
+		-locale US \
+		-error \
+		cmd/* docs/* *.md
+
+gofmt:  
+	@echo Checking code is gofmted
+	@test -z "$(shell gofmt -s -l -d -e $(SRCDIRS) | tee /dev/stderr)"
 
 image:
 	docker build . -t $(IMAGE):$(VERSION)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 gangway
+[![Build Status](https://travis-ci.org/heptiolabs/gangway.svg?branch=master)](https://travis-ci.org/heptiolabs/gangway)
 =======
 
 _(noun): An opening in the bulwark of the ship to allow passengers to board or leave the ship._

--- a/cmd/gangway/main.go
+++ b/cmd/gangway/main.go
@@ -62,8 +62,8 @@ func main() {
 		RedirectURL:  cfg.RedirectURL,
 		Scopes:       cfg.Scopes,
 		Endpoint: oauth2.Endpoint{
-			cfg.AuthorizeURL,
-			cfg.TokenURL,
+			AuthURL:  cfg.AuthorizeURL,
+			TokenURL: cfg.TokenURL,
 		},
 	}
 


### PR DESCRIPTION
Fixes #48 by enabling TravisCI for builds by doing a `make check` which does the following:

- test
- vet
- gofmt
- staticcheck
- unused
- misspell

This PR also fixes up errors to the new check to resolve nit spelling and code formatting issues. 