### PR TITLE
Moved kubeconfig download button location

### DIFF
--- a/templates/commandline.tmpl
+++ b/templates/commandline.tmpl
@@ -49,9 +49,10 @@ $ chmod +x ./kubectl
 $ sudo mv ./kubectl /usr/local/bin/kubectl
              </code>
            </pre>
-            <p>
-                Once kubectl is installed, you may execute the following:</b>
-            </p>
+            <div class="row">
+                <div class="col s12 right-align"><a href="/kubeconf" class="btn-large waves-effect waves-light blue">Download Kubeconfig</a></div>
+                <div class="col s12">Once kubectl is installed, you may execute the following:</div>
+            </div>       
             <pre>
                <code class="language-bash">
 echo "{{ .ClusterCA }}" \ > ca-{{ .ClusterName }}.pem
@@ -67,9 +68,6 @@ kubectl config set-context {{ .ClusterName }} --cluster={{ .ClusterName }} --use
 kubectl config use-context {{ .ClusterName }}
               </code>
             </pre>
-            <div class="row right">
-                <a href="/kubeconf" class="btn-large waves-effect waves-light blue">Download Kubeconfig</a>
-            </div>
         </div>
     </body>
 </html>


### PR DESCRIPTION
Fixes #55 

@swade1987 I moved this up to the middle. I thought it might fit logically better since the top part is downloading `kubectl` and the second 1/2 is configuring it.  Here's an example:

![screen shot 2018-10-16 at 1 39 56 pm](https://user-images.githubusercontent.com/1048184/47036221-01a25100-d14a-11e8-9a81-9edb15c1f2b0.png)

Signed-off-by: Steve Sloka <steves@heptio.com>