### PR TITLE
Enable path parameter to allow Gangway to be served other than '/'

### DIFF
--- a/cmd/gangway/config_test.go
+++ b/cmd/gangway/config_test.go
@@ -55,3 +55,36 @@ func TestEnvionmentOverrides(t *testing.T) {
 		t.Errorf("Failed to set scopes via environment variable. Expected %s but got %s", "[groups, sub]", cfg.Scopes)
 	}
 }
+
+func TestGetRootPathPrefix(t *testing.T) {
+	tests := map[string]struct {
+		path string
+		want string
+	}{
+		"not specified": {
+			path: "",
+			want: "/",
+		},
+		"specified": {
+			path: "/gangway",
+			want: "/gangway",
+		},
+		"specified default": {
+			path: "/",
+			want: "",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg := &Config{
+				HTTPPath: tc.path,
+			}
+
+			got := cfg.getRootPathPrefix()
+			if got != tc.want {
+				t.Fatalf("getRootPathPrefix(): want: %v, got: %v", tc.want, got)
+			}
+		})
+	}
+}

--- a/cmd/gangway/handlers_test.go
+++ b/cmd/gangway/handlers_test.go
@@ -33,6 +33,10 @@ func TestHomeHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	cfg = &Config{
+		HTTPPath: "",
+	}
+
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(homeHandler)
 

--- a/cmd/gangway/main.go
+++ b/cmd/gangway/main.go
@@ -98,14 +98,14 @@ func main() {
 
 	loginRequiredHandlers := alice.New(loginRequired)
 
-	http.HandleFunc("/", httpLogger(homeHandler))
-	http.HandleFunc("/login", httpLogger(loginHandler))
-	http.HandleFunc("/callback", httpLogger(callbackHandler))
+	http.HandleFunc(cfg.getRootPathPrefix(), httpLogger(homeHandler))
+	http.HandleFunc(fmt.Sprintf("%s/login", cfg.HTTPPath), httpLogger(loginHandler))
+	http.HandleFunc(fmt.Sprintf("%s/callback", cfg.HTTPPath), httpLogger(callbackHandler))
 
 	// middleware'd routes
-	http.Handle("/logout", loginRequiredHandlers.ThenFunc(logoutHandler))
-	http.Handle("/commandline", loginRequiredHandlers.ThenFunc(commandlineHandler))
-	http.Handle("/kubeconf", loginRequiredHandlers.ThenFunc(kubeConfigHandler))
+	http.Handle(fmt.Sprintf("%s/logout", cfg.HTTPPath), loginRequiredHandlers.ThenFunc(logoutHandler))
+	http.Handle(fmt.Sprintf("%s/commandline", cfg.HTTPPath), loginRequiredHandlers.ThenFunc(commandlineHandler))
+	http.Handle(fmt.Sprintf("%s/kubeconf", cfg.HTTPPath), loginRequiredHandlers.ThenFunc(kubeConfigHandler))
 
 	bindAddr := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
 	// create http server with timeouts

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,13 @@ kubectl -n gangway create secret generic gangway-key \
   --from-literal=sesssionkey=$(openssl rand -base64 32)
 ```
 
+## Path Prefix
+
+Gangway takes an optional path prefix if you want to host it at a url other than '/' (e.g. `https://example.com/gangway`).
+By configuring this parameter, all redirects will have the proper path appended to the url parameters.
+
+This variable can be configured via the (ConfigMap)[https://github.com/heptiolabs/gangway/blob/master/docs/yaml/02-config.yaml#L81] or via environment variable (`GANGWAY_HTTP_PATH`).
+
 ## Detailed Instructions
 
 The following guide is a more detailed review of how to get Gangway and other components configured in an AWS environment.

--- a/docs/yaml/02-config.yaml
+++ b/docs/yaml/02-config.yaml
@@ -79,3 +79,7 @@ data:
     # a Kubernetes cluster and doesn't need to be set.
     # Env var: GANGWAY_CLUSTER_CA_PATH
     # cluster_ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+    # The path gangway uses to create urls (defaults to "")
+    # Env var: GANGWAY_HTTP_PATH
+    #httpPath: "https://${GANGWAY_HTTP_PATH}"

--- a/templates/commandline.tmpl
+++ b/templates/commandline.tmpl
@@ -50,7 +50,7 @@ $ sudo mv ./kubectl /usr/local/bin/kubectl
              </code>
            </pre>
             <div class="row">
-                <div class="col s12 right-align"><a href="/kubeconf" class="btn-large waves-effect waves-light blue">Download Kubeconfig</a></div>
+                <div class="col s12 right-align"><a href="{{ .HTTPPath }}/kubeconf" class="btn-large waves-effect waves-light blue">Download Kubeconfig</a></div>
                 <div class="col s12">Once kubectl is installed, you may execute the following:</div>
             </div>       
             <pre>

--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0"/>
-  <title>gangway</title>
+  <title>Heptio Gangway</title>
 
   <!-- CSS  -->
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
@@ -43,19 +43,17 @@
   <div class="section no-pad-bot" id="index-banner">
     <div class="container">
       <br><br>
-      <h1 class="header center darken-3">gangway Kubernetes Authentication</h1>
+      <h1 class="header center darken-3">Heptio Gangway Kubernetes Authentication</h1>
       <div class="row center">
         <h5 class="header col s12 light">This utility will help you authenticate with your Kubernetes cluster with an OpenID Connect (OIDC) flow. Sign in to get started.</h5>
       </div>
       <div class="row center">
-        <a href="/login"" id="download-button" class="btn-large waves-effect waves-light blue">Sign In</a>
+        <a href="{{ .HTTPPath }}/login" id="download-button" class="btn-large waves-effect waves-light blue">Sign In</a>
       </div>
       <br><br>
 
     </div>
   </div>
-
-
   
 
   <!--  Scripts-->


### PR DESCRIPTION
Fixes #41 by introducing a `httpPath` parameter which configures Gangway to use an alternate http path other than `/`. The variable can be configured via the ConfigMap or ENV variable. 

Signed-off-by: Steve Sloka <steves@heptio.com>