### PR TITLE
Fix context in kubeconfig template

### DIFF
--- a/templates/kubeconfig.tmpl
+++ b/templates/kubeconfig.tmpl
@@ -7,7 +7,7 @@ clusters:
 contexts:
 - context:
     cluster: {{ .ClusterName }}
-    user: {{ .Email }}
+    user: {{ .Username }}@{{ .ClusterName }}
   name: {{ .ClusterName }}
 current-context: {{ .ClusterName }}
 kind: Config


### PR DESCRIPTION
Followup from #75
I neglected to adjust the context to reflect the changes to the user.
This fixes that.

Signed-off-by: Pete Brown <pete.brown@powerhrg.com>