### PR TITLE
[do not merge] Changes to make gangway work on PKS

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,7 +102,7 @@ func (cfg *Config) Validate() error {
 		{cfg.AuthorizeURL == "", "no authorizeURL specified"},
 		{cfg.TokenURL == "", "no tokenURL specified"},
 		{cfg.ClientID == "", "no clientID specified"},
-		{cfg.ClientSecret == "", "no clientSecret specified"},
+		//{cfg.ClientSecret == "", "no clientSecret specified"},
 		{cfg.RedirectURL == "", "no redirectURL specified"},
 		{cfg.SessionSecurityKey == "", "no SessionSecurityKey specified"},
 		{cfg.APIServerURL == "", "no apiServerURL specified"},

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -16,7 +16,6 @@ package session
 
 import (
 	"crypto/sha256"
-	"math"
 	"net/http"
 
 	"github.com/gorilla/sessions"
@@ -27,18 +26,13 @@ const salt = "MkmfuPNHnZBBivy0L0aW"
 
 // Session defines a Gangway session
 type Session struct {
-	//Session2 *sessions.CookieStore
-	Session *sessions.FilesystemStore
+	Session *sessions.CookieStore
 }
 
 // New inits a Session with CookieStore
 func New(sessionSecurityKey string) *Session {
-	k1, k2 := generateSessionKeys(sessionSecurityKey)
-	store := sessions.NewFilesystemStore("", k1, k2)
-	store.MaxLength(math.MaxInt64)
 	return &Session{
-		//Session2: sessions.NewCookieStore(sessionKey),
-		Session: store,
+		Session: sessions.NewCookieStore(generateSessionKeys(sessionSecurityKey)),
 	}
 }
 
@@ -56,8 +50,8 @@ func generateSessionKeys(sessionSecurityKey string) ([]byte, []byte) {
 }
 
 // Cleanup removes the current session from the store
-func (s *Session) Cleanup(w http.ResponseWriter, r *http.Request) {
-	session, err := s.Session.Get(r, "gangway")
+func (s *Session) Cleanup(w http.ResponseWriter, r *http.Request, name string) {
+	session, err := s.Session.Get(r, name)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -16,6 +16,7 @@ package session
 
 import (
 	"crypto/sha256"
+	"math"
 	"net/http"
 
 	"github.com/gorilla/sessions"
@@ -26,13 +27,18 @@ const salt = "MkmfuPNHnZBBivy0L0aW"
 
 // Session defines a Gangway session
 type Session struct {
-	Session *sessions.CookieStore
+	//Session2 *sessions.CookieStore
+	Session *sessions.FilesystemStore
 }
 
 // New inits a Session with CookieStore
 func New(sessionSecurityKey string) *Session {
+	k1, k2 := generateSessionKeys(sessionSecurityKey)
+	store := sessions.NewFilesystemStore("", k1, k2)
+	store.MaxLength(math.MaxInt64)
 	return &Session{
-		Session: sessions.NewCookieStore(generateSessionKeys(sessionSecurityKey)),
+		//Session2: sessions.NewCookieStore(sessionKey),
+		Session: store,
 	}
 }
 

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -47,7 +47,7 @@ func TestCleanupSession(t *testing.T) {
 	// create a test http server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		session, _ = s.Session.Get(r, "gangway")
-		s.Cleanup(w, r)
+		s.Cleanup(w, r, "gangway")
 
 	}))
 	defer ts.Close()

--- a/templates/commandline.tmpl
+++ b/templates/commandline.tmpl
@@ -52,19 +52,19 @@ $ sudo mv ./kubectl /usr/local/bin/kubectl
             <div class="row">
                 <div class="col s12 right-align"><a href="{{ .HTTPPath }}/kubeconf" class="btn-large waves-effect waves-light blue">Download Kubeconfig</a></div>
                 <div class="col s12">Once kubectl is installed, you may execute the following:</div>
-            </div>       
+            </div>
             <pre>
                <code class="language-bash">
 echo "{{ .ClusterCA }}" \ > ca-{{ .ClusterName }}.pem
 kubectl config set-cluster {{ .ClusterName }} --server={{ .APIServerURL }} --certificate-authority=ca-{{ .ClusterName }}.pem --embed-certs
-kubectl config set-credentials {{ .Username }}@{{ .ClusterName }}  \
+kubectl config set-credentials {{ .Email }}  \
     --auth-provider=oidc  \
     --auth-provider-arg=idp-issuer-url={{ .IssuerURL }}  \
     --auth-provider-arg=client-id={{ .ClientID }}  \
     --auth-provider-arg=client-secret={{ .ClientSecret }} \
     --auth-provider-arg=refresh-token={{ .RefreshToken }} \
     --auth-provider-arg=id-token={{ .IDToken }}
-kubectl config set-context {{ .ClusterName }} --cluster={{ .ClusterName }} --user={{ .Username }}@{{ .ClusterName }}
+kubectl config set-context {{ .ClusterName }} --cluster={{ .ClusterName }} --user={{ .Email }}
 kubectl config use-context {{ .ClusterName }}
               </code>
             </pre>

--- a/templates/kubeconfig.tmpl
+++ b/templates/kubeconfig.tmpl
@@ -13,7 +13,7 @@ current-context: {{ .ClusterName }}
 kind: Config
 preferences: {}
 users:
-- name: {{ .Username }}@{{ .ClusterName }}
+- name: {{ .Email }}
   user:
     auth-provider:
       config:


### PR DESCRIPTION
I Had to change a few things to make it work correctly.  Here's a PR to show the diffs, I don't expect this to get merged, its more informational at this stage.

* had to store sessions on disk to make them fit ( see #26 )
* had to allow empty client secret (is this even a good idea?  I don't know, but its what PKS
supports today) 

* fixed the kubeconfig template to not use both `{{.Email}}` and `{{ .Username }}@{{ .ClusterName }}` for what should be the same resultant value.