### PR TITLE
Fix alternating use of .Email and .Username@.Cluster

### DIFF
--- a/templates/kubeconfig.tmpl
+++ b/templates/kubeconfig.tmpl
@@ -13,7 +13,7 @@ current-context: {{ .ClusterName }}
 kind: Config
 preferences: {}
 users:
-- name: {{ .Username }}@{{ .ClusterName }}
+- name: {{ .Email }}
   user:
     auth-provider:
       config:


### PR DESCRIPTION
The user field should match up and therefore should come from the
correct value. From looking at the config file its apparent that
.Email is the correct value.

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>