### PR TITLE
remove check for non-empty client secret.

### DIFF
--- a/cmd/gangway/handlers.go
+++ b/cmd/gangway/handlers.go
@@ -249,6 +249,10 @@ func commandlineHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if cfg.ClientSecret == "" {
+		log.Warn("Setting an empty Client Secret should only be done if you have no other option and is an inherent security risk.")
+	}
+
 	info := &userInfo{
 		ClusterName:  cfg.ClusterName,
 		Username:     username,

--- a/docs/yaml/02-config.yaml
+++ b/docs/yaml/02-config.yaml
@@ -60,6 +60,12 @@ data:
     # Env var: GANGWAY_CLIENT_SECRET
     clientSecret: "${GANGWAY_CLIENT_SECRET}"
 
+    # Some identity providers accept an empty client secret, this
+    # is not generally considered a good idea. If you have to use an
+    # empty secret and accept the risks that come with that then you can
+    # set this to true.
+    #allowEmptyClientSecret: false
+
     # The JWT claim to use as the username. This is used in UI.
     # Default is "nickname". This is combined with the clusterName
     # for the "user" portion of the kubeconfig.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,7 +102,6 @@ func (cfg *Config) Validate() error {
 		{cfg.AuthorizeURL == "", "no authorizeURL specified"},
 		{cfg.TokenURL == "", "no tokenURL specified"},
 		{cfg.ClientID == "", "no clientID specified"},
-		{cfg.ClientSecret == "", "no clientSecret specified"},
 		{cfg.RedirectURL == "", "no redirectURL specified"},
 		{cfg.SessionSecurityKey == "", "no SessionSecurityKey specified"},
 		{cfg.APIServerURL == "", "no apiServerURL specified"},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,23 +28,24 @@ type Config struct {
 	Host string `yaml:"host"`
 	Port int    `yaml:"port"`
 
-	ClusterName   string   `yaml:"clusterName" envconfig:"cluster_name"`
-	AuthorizeURL  string   `yaml:"authorizeURL" envconfig:"authorize_url"`
-	TokenURL      string   `yaml:"tokenURL" envconfig:"token_url"`
-	ClientID      string   `yaml:"clientID" envconfig:"client_id"`
-	ClientSecret  string   `yaml:"clientSecret" envconfig:"client_secret"`
-	Audience      string   `yaml:"audience" envconfig:"audience"`
-	RedirectURL   string   `yaml:"redirectURL" envconfig:"redirect_url"`
-	Scopes        []string `yaml:"scopes" envconfig:"scopes"`
-	UsernameClaim string   `yaml:"usernameClaim" envconfig:"username_claim"`
-	EmailClaim    string   `yaml:"emailClaim" envconfig:"email_claim"`
-	ServeTLS      bool     `yaml:"serveTLS" envconfig:"serve_tls"`
-	CertFile      string   `yaml:"certFile" envconfig:"cert_file"`
-	KeyFile       string   `yaml:"keyFile" envconfig:"key_file"`
-	APIServerURL  string   `yaml:"apiServerURL" envconfig:"apiserver_url"`
-	ClusterCAPath string   `yaml:"clusterCAPath" envconfig:"cluster_ca_path"`
-	TrustedCAPath string   `yaml:"trustedCAPath" envconfig:"trusted_ca_path"`
-	HTTPPath      string   `yaml:"httpPath" envconfig:"http_path"`
+	ClusterName            string   `yaml:"clusterName" envconfig:"cluster_name"`
+	AuthorizeURL           string   `yaml:"authorizeURL" envconfig:"authorize_url"`
+	TokenURL               string   `yaml:"tokenURL" envconfig:"token_url"`
+	ClientID               string   `yaml:"clientID" envconfig:"client_id"`
+	ClientSecret           string   `yaml:"clientSecret" envconfig:"client_secret"`
+	AllowEmptyClientSecret bool     `yaml:"allowEmptyClientSecret" envconfig:"allow_empty_client_secret"`
+	Audience               string   `yaml:"audience" envconfig:"audience"`
+	RedirectURL            string   `yaml:"redirectURL" envconfig:"redirect_url"`
+	Scopes                 []string `yaml:"scopes" envconfig:"scopes"`
+	UsernameClaim          string   `yaml:"usernameClaim" envconfig:"username_claim"`
+	EmailClaim             string   `yaml:"emailClaim" envconfig:"email_claim"`
+	ServeTLS               bool     `yaml:"serveTLS" envconfig:"serve_tls"`
+	CertFile               string   `yaml:"certFile" envconfig:"cert_file"`
+	KeyFile                string   `yaml:"keyFile" envconfig:"key_file"`
+	APIServerURL           string   `yaml:"apiServerURL" envconfig:"apiserver_url"`
+	ClusterCAPath          string   `yaml:"clusterCAPath" envconfig:"cluster_ca_path"`
+	TrustedCAPath          string   `yaml:"trustedCAPath" envconfig:"trusted_ca_path"`
+	HTTPPath               string   `yaml:"httpPath" envconfig:"http_path"`
 
 	SessionSecurityKey string `yaml:"sessionSecurityKey" envconfig:"SESSION_SECURITY_KEY"`
 }
@@ -53,16 +54,17 @@ type Config struct {
 func NewConfig(configFile string) (*Config, error) {
 
 	cfg := &Config{
-		Host:          "0.0.0.0",
-		Port:          8080,
-		Scopes:        []string{"openid", "profile", "email", "offline_access"},
-		UsernameClaim: "nickname",
-		EmailClaim:    "email",
-		ServeTLS:      false,
-		CertFile:      "/etc/gangway/tls/tls.crt",
-		KeyFile:       "/etc/gangway/tls/tls.key",
-		ClusterCAPath: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
-		HTTPPath:      "",
+		Host: "0.0.0.0",
+		Port: 8080,
+		AllowEmptyClientSecret: false,
+		Scopes:                 []string{"openid", "profile", "email", "offline_access"},
+		UsernameClaim:          "nickname",
+		EmailClaim:             "email",
+		ServeTLS:               false,
+		CertFile:               "/etc/gangway/tls/tls.crt",
+		KeyFile:                "/etc/gangway/tls/tls.key",
+		ClusterCAPath:          "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+		HTTPPath:               "",
 	}
 
 	if configFile != "" {
@@ -102,6 +104,7 @@ func (cfg *Config) Validate() error {
 		{cfg.AuthorizeURL == "", "no authorizeURL specified"},
 		{cfg.TokenURL == "", "no tokenURL specified"},
 		{cfg.ClientID == "", "no clientID specified"},
+		{cfg.ClientSecret == "" && !cfg.AllowEmptyClientSecret, "no clientSecret specified"},
 		{cfg.RedirectURL == "", "no redirectURL specified"},
 		{cfg.SessionSecurityKey == "", "no SessionSecurityKey specified"},
 		{cfg.APIServerURL == "", "no apiServerURL specified"},


### PR DESCRIPTION
It's valid (but probably not advisable) to have a non-empty client secret,
example currently PKS clusters authorizing via UAA contain an empty
secret, therefore this is necessary for it to work.

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>