### PR TITLE
[Fix #26] create multiple session cookies

### DIFF
--- a/cmd/gangway/handlers_test.go
+++ b/cmd/gangway/handlers_test.go
@@ -190,6 +190,8 @@ func TestCommandLineHandler(t *testing.T) {
 			var req *http.Request
 			var rsp *httptest.ResponseRecorder
 			var session *sessions.Session
+			var sessionIDToken *sessions.Session
+			var sessionRefreshToken *sessions.Session
 			var err error
 
 			cfg = &config.Config{
@@ -211,12 +213,24 @@ func TestCommandLineHandler(t *testing.T) {
 			if session, err = gangwayUserSession.Session.Get(req, "gangway"); err != nil {
 				t.Fatalf("Error getting session: %v", err)
 			}
+			if sessionIDToken, err = gangwayUserSession.Session.Get(req, "gangway_id_token"); err != nil {
+				t.Fatalf("Error getting session: %v", err)
+			}
+			if sessionRefreshToken, err = gangwayUserSession.Session.Get(req, "gangway_refresh_token"); err != nil {
+				t.Fatalf("Error getting session: %v", err)
+			}
 
 			// Create state session variable
 			session.Values["state"] = tc.params["state"]
-			session.Values["id_token"] = tc.params["id_token"]
-			session.Values["refresh_token"] = tc.params["refresh_token"]
+			sessionIDToken.Values["id_token"] = tc.params["id_token"]
+			sessionRefreshToken.Values["refresh_token"] = tc.params["refresh_token"]
 			if err = session.Save(req, rsp); err != nil {
+				t.Fatal(err)
+			}
+			if err = sessionIDToken.Save(req, rsp); err != nil {
+				t.Fatal(err)
+			}
+			if err = sessionRefreshToken.Save(req, rsp); err != nil {
 				t.Fatal(err)
 			}
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -50,8 +50,8 @@ func generateSessionKeys(sessionSecurityKey string) ([]byte, []byte) {
 }
 
 // Cleanup removes the current session from the store
-func (s *Session) Cleanup(w http.ResponseWriter, r *http.Request) {
-	session, err := s.Session.Get(r, "gangway")
+func (s *Session) Cleanup(w http.ResponseWriter, r *http.Request, name string) {
+	session, err := s.Session.Get(r, name)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -47,7 +47,7 @@ func TestCleanupSession(t *testing.T) {
 	// create a test http server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		session, _ = s.Session.Get(r, "gangway")
-		s.Cleanup(w, r)
+		s.Cleanup(w, r, "gangway")
 
 	}))
 	defer ts.Close()


### PR DESCRIPTION
When used with auth systems that create large keys (UAA) storing
sessions as cookies can cause the cookie to be larger than
browsers like. This somewhat awkwardly seperates id_token and
refresh_token out into their own cookies.

You could also switch out to filesystem or redis for session storage
but that adds more complication for runtime than this super simple use
case really warrants IMHO.

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>