### PR TITLE
Deprecate use of emailClaim.

### DIFF
--- a/cmd/gangway/handlers.go
+++ b/cmd/gangway/handlers.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/dgrijalva/jwt-go"
@@ -232,12 +233,14 @@ func commandlineHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Could not parse Username claim", http.StatusInternalServerError)
 		return
 	}
-
-	email, ok := claims[cfg.EmailClaim].(string)
-	if !ok {
-		http.Error(w, "Could not parse Email claim", http.StatusInternalServerError)
-		log.Println("email Handler")
-		return
+	email := strings.Join([]string{username, cfg.ClusterName}, "@")
+	if cfg.EmailClaim != "" {
+		email, ok = claims[cfg.EmailClaim].(string)
+		if !ok {
+			http.Error(w, "Could not parse Email claim", http.StatusInternalServerError)
+			log.Warn("using the Email Claim config setting is deprecated. In future Gangway will use `UsernameClaim@ClusterName`")
+			return
+		}
 	}
 
 	issuerURL, ok := claims["iss"].(string)

--- a/docs/yaml/02-config.yaml
+++ b/docs/yaml/02-config.yaml
@@ -61,14 +61,10 @@ data:
     clientSecret: "${GANGWAY_CLIENT_SECRET}"
 
     # The JWT claim to use as the username. This is used in UI.
-    # Default is "nickname".
+    # Default is "nickname". This is combined with the clusterName
+    # for the "user" portion of the kubeconfig.
     # Env var: GANGWAY_USERNAME_CLAIM
     usernameClaim: "sub"
-
-    # The JWT claim to use as the email claim. This is used to name the
-    # "user" part of the config. Default is "email".
-    # Env var: GANGWAY_EMAIL_CLAIM
-    emailClaim: "email"
 
     # The API server endpoint used to configure kubectl
     # Env var: GANGWAY_APISERVER_URL
@@ -79,6 +75,10 @@ data:
     # a Kubernetes cluster and doesn't need to be set.
     # Env var: GANGWAY_CLUSTER_CA_PATH
     # cluster_ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+    # The path to a root CA to trust for self signed certificates at the Oauth2 URLs
+    # Env var: GANGWAY_TRUSTED_CA_PATH
+    #trustedCAPath: /cacerts/rootca.crt
 
     # The path gangway uses to create urls (defaults to "")
     # Env var: GANGWAY_HTTP_PATH

--- a/templates/commandline.tmpl
+++ b/templates/commandline.tmpl
@@ -57,14 +57,14 @@ $ sudo mv ./kubectl /usr/local/bin/kubectl
                <code class="language-bash">
 echo "{{ .ClusterCA }}" \ > ca-{{ .ClusterName }}.pem
 kubectl config set-cluster {{ .ClusterName }} --server={{ .APIServerURL }} --certificate-authority=ca-{{ .ClusterName }}.pem --embed-certs
-kubectl config set-credentials {{ .Username }}@{{ .ClusterName }}  \
+kubectl config set-credentials {{ .Email }}  \
     --auth-provider=oidc  \
     --auth-provider-arg=idp-issuer-url={{ .IssuerURL }}  \
     --auth-provider-arg=client-id={{ .ClientID }}  \
     --auth-provider-arg=client-secret={{ .ClientSecret }} \
     --auth-provider-arg=refresh-token={{ .RefreshToken }} \
     --auth-provider-arg=id-token={{ .IDToken }}
-kubectl config set-context {{ .ClusterName }} --cluster={{ .ClusterName }} --user={{ .Username }}@{{ .ClusterName }}
+kubectl config set-context {{ .ClusterName }} --cluster={{ .ClusterName }} --user={{ .Email }}
 kubectl config use-context {{ .ClusterName }}
               </code>
             </pre>

--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -54,7 +54,7 @@
 
     </div>
   </div>
-  
+
 
   <!--  Scripts-->
   <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
@@ -63,4 +63,3 @@
 
   </body>
 </html>
-

--- a/templates/kubeconfig.tmpl
+++ b/templates/kubeconfig.tmpl
@@ -7,13 +7,13 @@ clusters:
 contexts:
 - context:
     cluster: {{ .ClusterName }}
-    user: {{ .Username }}@{{ .ClusterName }}
+    user: {{ .Email }}
   name: {{ .ClusterName }}
 current-context: {{ .ClusterName }}
 kind: Config
 preferences: {}
 users:
-- name: {{ .Username }}@{{ .ClusterName }}
+- name: {{ .Email }}
   user:
     auth-provider:
       config:


### PR DESCRIPTION
In order to support multiple clusters in the future we need each
username in the kubeconfig to be unique.  Therefore rather than using
the user's email from their oidc auth, we should construct it from
usernameClaim and clusterName.

Of course we should also deprecate it nicely, so if emailClaim is set
it will override that default and still use their OIDC email address and
print a warning message in the logs.

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>