### PR TITLE
Use crypto/rand to generate random number, instead of weak math/rand

### DIFF
--- a/cmd/gangway/handlers.go
+++ b/cmd/gangway/handlers.go
@@ -17,10 +17,10 @@ package main
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"net/http"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
Math/rand is not recommended for security-sensitive use cases. Switch to crypto/rand instead.