### PR TITLE
Bump go version to v1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go_import_path: github.com/heptiolabs/gangway
 go:
-  - 1.10.x
+  - 1.12.x
 
 sudo: false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9
+FROM golang:1.12
 WORKDIR /go/src/github.com/heptiolabs/gangway
 
 RUN go get github.com/golang/dep/cmd/dep

--- a/cmd/gangway/handlers.go
+++ b/cmd/gangway/handlers.go
@@ -104,7 +104,7 @@ func generateKubeConfig(cfg *userInfo) clientcmdapi.Config {
 			{
 				Name: cfg.ClusterName,
 				Cluster: clientcmdapi.Cluster{
-					Server: cfg.APIServerURL,
+					Server:                   cfg.APIServerURL,
 					CertificateAuthorityData: []byte(caData),
 				},
 			},


### PR DESCRIPTION
Fixes #109 

Gofmt changed between v1.9 and v1.12, so a file had to be updated with new formatting.