### PR TITLE
Enquote --auth-provider-arg values

### DIFF
--- a/templates/commandline.tmpl
+++ b/templates/commandline.tmpl
@@ -59,11 +59,11 @@ echo "{{ .ClusterCA }}" \ > ca-{{ .ClusterName }}.pem
 kubectl config set-cluster {{ .ClusterName }} --server={{ .APIServerURL }} --certificate-authority=ca-{{ .ClusterName }}.pem --embed-certs
 kubectl config set-credentials {{ .Email }}  \
     --auth-provider=oidc  \
-    --auth-provider-arg=idp-issuer-url={{ .IssuerURL }}  \
-    --auth-provider-arg=client-id={{ .ClientID }}  \
-    --auth-provider-arg=client-secret={{ .ClientSecret }} \
-    --auth-provider-arg=refresh-token={{ .RefreshToken }} \
-    --auth-provider-arg=id-token={{ .IDToken }}
+    --auth-provider-arg='idp-issuer-url={{ .IssuerURL }}'  \
+    --auth-provider-arg='client-id={{ .ClientID }}'  \
+    --auth-provider-arg='client-secret={{ .ClientSecret }}' \
+    --auth-provider-arg='refresh-token={{ .RefreshToken }}' \
+    --auth-provider-arg='id-token={{ .IDToken }}'
 kubectl config set-context {{ .ClusterName }} --cluster={{ .ClusterName }} --user={{ .Email }}
 kubectl config use-context {{ .ClusterName }}
 rm ca-{{ .ClusterName }}.pem


### PR DESCRIPTION
In a client secret for example there could be characters which won't play well with your shell like ! or | and many more.
For this reason enquoting of these values is safer.