### PR TITLE
Add namespace claim to config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,7 @@ The following table describes the options that can be set via the YAML configura
 | `clientSecret` | API client secret as indicated by the identity provider |
 | `allowEmptyClientSecret` | Some identity providers accept an empty client secret, this is not generally considered a good idea. If you have to use an empty secret and accept the risks that come with that then you can set this to true. Defaults to `false`. |
 | `usernameClaim` | The JWT claim to use as the username. This is used in UI. This is combined with the clusterName for the "user" portion of the kubeconfig. Defaults to `nickname`. |
+| `namespaceClaim` | The JWT claim to use as the namespace. This is used to set a namespace in the kubeconfig context. Leave unset for default namespace. |
 | `emailClaim` | Deprecated. Defaults to `email`. |
 | `apiServerURL` | The API server endpoint used to configure kubectl |
 | `clusterCAPath` | The path to find the CA bundle for the API server. Used to configure kubectl. This is typically mounted into the default location for workloads running on a Kubernetes cluster and doesn't need to be set. Defaults to `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	Scopes                 []string `yaml:"scopes" envconfig:"scopes"`
 	UsernameClaim          string   `yaml:"usernameClaim" envconfig:"username_claim"`
 	EmailClaim             string   `yaml:"emailClaim" envconfig:"email_claim"`
+	NamespaceClaim         string   `yaml:"namespaceClaim" envconfig:"namespace_claim"`
 	ServeTLS               bool     `yaml:"serveTLS" envconfig:"serve_tls"`
 	CertFile               string   `yaml:"certFile" envconfig:"cert_file"`
 	KeyFile                string   `yaml:"keyFile" envconfig:"key_file"`
@@ -55,12 +56,13 @@ type Config struct {
 func NewConfig(configFile string) (*Config, error) {
 
 	cfg := &Config{
-		Host:                   "0.0.0.0",
-		Port:                   8080,
+		Host: "0.0.0.0",
+		Port: 8080,
 		AllowEmptyClientSecret: false,
 		Scopes:                 []string{"openid", "profile", "email", "offline_access"},
 		UsernameClaim:          "nickname",
 		EmailClaim:             "email",
+		NamespaceClaim:         "",
 		ServeTLS:               false,
 		CertFile:               "/etc/gangway/tls/tls.crt",
 		KeyFile:                "/etc/gangway/tls/tls.key",

--- a/templates/commandline.tmpl
+++ b/templates/commandline.tmpl
@@ -59,12 +59,12 @@ echo "{{ .ClusterCA }}" \ > ca-{{ .ClusterName }}.pem
 kubectl config set-cluster {{ .ClusterName }} --server={{ .APIServerURL }} --certificate-authority=ca-{{ .ClusterName }}.pem --embed-certs
 kubectl config set-credentials {{ .Email }}  \
     --auth-provider=oidc  \
-    --auth-provider-arg='idp-issuer-url={{ .IssuerURL }}'  \
-    --auth-provider-arg='client-id={{ .ClientID }}'  \
-    --auth-provider-arg='client-secret={{ .ClientSecret }}' \
-    --auth-provider-arg='refresh-token={{ .RefreshToken }}' \
-    --auth-provider-arg='id-token={{ .IDToken }}'
-kubectl config set-context {{ .ClusterName }} --cluster={{ .ClusterName }} --user={{ .Email }}
+    --auth-provider-arg=idp-issuer-url={{ .IssuerURL }}  \
+    --auth-provider-arg=client-id={{ .ClientID }}  \
+    --auth-provider-arg=client-secret={{ .ClientSecret }} \
+    --auth-provider-arg=refresh-token={{ .RefreshToken }} \
+    --auth-provider-arg=id-token={{ .IDToken }}
+kubectl config set-context {{ .ClusterName }} --cluster={{ .ClusterName }} --user={{ .Email }} --namespace={{ .Namespace }}
 kubectl config use-context {{ .ClusterName }}
 rm ca-{{ .ClusterName }}.pem
               </code>


### PR DESCRIPTION
This allows you to set a JWT claim to use for the namespace field to be filled
out in the kubeconfig. Useful if you give each user their own namespace.  If left
out, will be left blank in kubeconfig and thus default namespace.

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>