### PR TITLE
Fix kubeconfig --user value

### DIFF
--- a/cmd/gangway/handlers_test.go
+++ b/cmd/gangway/handlers_test.go
@@ -155,17 +155,6 @@ func TestCommandLineHandler(t *testing.T) {
 			emailClaim:                 "Email",
 			usernameClaim:              "sub",
 		},
-		"incorrect email claim": {
-			params: map[string]string{
-				"state":         "Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk=",
-				"id_token":      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHYW5nd2F5VGVzdCIsImlhdCI6MTU0MDA0NjM0NywiZXhwIjoxODg3MjAxNTQ3LCJhdWQiOiJnYW5nd2F5LmhlcHRpby5jb20iLCJzdWIiOiJnYW5nd2F5QGhlcHRpby5jb20iLCJHaXZlbk5hbWUiOiJHYW5nIiwiU3VybmFtZSI6IldheSIsIkVtYWlsIjoiZ2FuZ3dheUBoZXB0aW8uY29tIiwiR3JvdXBzIjoiZGV2LGFkbWluIn0.zNG4Dnxr76J0p4phfsAUYWunioct0krkMiunMynlQsU",
-				"refresh_token": "bar",
-				"code":          "0cj0VQzNl36e4P2L&state=jdep4ov52FeUuzWLDDtSXaF4b5%2F%2FCUJ52xlE69ehnQ8%3D",
-			},
-			expectedStatusCode: http.StatusInternalServerError,
-			emailClaim:         "meh",
-			usernameClaim:      "sub",
-		},
 		"incorrect username claim": {
 			params: map[string]string{
 				"state":         "Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk=",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,7 +60,7 @@ func NewConfig(configFile string) (*Config, error) {
 		AllowEmptyClientSecret: false,
 		Scopes:                 []string{"openid", "profile", "email", "offline_access"},
 		UsernameClaim:          "nickname",
-		EmailClaim:             "email",
+		EmailClaim:             "",
 		ServeTLS:               false,
 		CertFile:               "/etc/gangway/tls/tls.crt",
 		KeyFile:                "/etc/gangway/tls/tls.key",

--- a/templates/commandline.tmpl
+++ b/templates/commandline.tmpl
@@ -57,14 +57,14 @@ $ sudo mv ./kubectl /usr/local/bin/kubectl
                <code class="language-bash">
 echo "{{ .ClusterCA }}" \ > ca-{{ .ClusterName }}.pem
 kubectl config set-cluster {{ .ClusterName }} --server={{ .APIServerURL }} --certificate-authority=ca-{{ .ClusterName }}.pem --embed-certs
-kubectl config set-credentials {{ .Email }}  \
+kubectl config set-credentials {{ .KubeCfgUser }}  \
     --auth-provider=oidc  \
     --auth-provider-arg='idp-issuer-url={{ .IssuerURL }}'  \
     --auth-provider-arg='client-id={{ .ClientID }}'  \
     --auth-provider-arg='client-secret={{ .ClientSecret }}' \
     --auth-provider-arg='refresh-token={{ .RefreshToken }}' \
     --auth-provider-arg='id-token={{ .IDToken }}'
-kubectl config set-context {{ .ClusterName }} --cluster={{ .ClusterName }} --user={{ .Email }}
+kubectl config set-context {{ .ClusterName }} --cluster={{ .ClusterName }} --user={{ .KubeCfgUser }}
 kubectl config use-context {{ .ClusterName }}
 rm ca-{{ .ClusterName }}.pem
               </code>


### PR DESCRIPTION
Recent changes to set the kubeconfig user to `user@cluster` aren't
taking effect due to a default always being present and not triggering
the logic. This removes the default and allows the proper behavior
to work.

Fixes #125

Signed-off-by: John Harris <joharris@vmware.com>