### PR TITLE
fix: Commands from commandline template fail when cluster name or credential name contain spaces

### DIFF
--- a/templates/commandline.tmpl
+++ b/templates/commandline.tmpl
@@ -55,18 +55,18 @@ $ sudo mv ./kubectl /usr/local/bin/kubectl
             </div>
             <pre>
                <code class="language-bash">
-echo "{{ .ClusterCA }}" \ > ca-{{ .ClusterName }}.pem
-kubectl config set-cluster {{ .ClusterName }} --server={{ .APIServerURL }} --certificate-authority=ca-{{ .ClusterName }}.pem --embed-certs
-kubectl config set-credentials {{ .KubeCfgUser }}  \
+echo "{{ .ClusterCA }}" \ > "ca-{{ .ClusterName }}.pem"
+kubectl config set-cluster "{{ .ClusterName }}" --server={{ .APIServerURL }} --certificate-authority="ca-{{ .ClusterName }}.pem" --embed-certs
+kubectl config set-credentials "{{ .KubeCfgUser }}"  \
     --auth-provider=oidc  \
     --auth-provider-arg='idp-issuer-url={{ .IssuerURL }}'  \
     --auth-provider-arg='client-id={{ .ClientID }}'  \
     --auth-provider-arg='client-secret={{ .ClientSecret }}' \
     --auth-provider-arg='refresh-token={{ .RefreshToken }}' \
     --auth-provider-arg='id-token={{ .IDToken }}'
-kubectl config set-context {{ .ClusterName }} --cluster={{ .ClusterName }} --user={{ .KubeCfgUser }}
-kubectl config use-context {{ .ClusterName }}
-rm ca-{{ .ClusterName }}.pem
+kubectl config set-context "{{ .ClusterName }}" --cluster="{{ .ClusterName }}" --user="{{ .KubeCfgUser }}"
+kubectl config use-context "{{ .ClusterName }}"
+rm "ca-{{ .ClusterName }}.pem"
               </code>
             </pre>
         </div>


### PR DESCRIPTION
Fixes https://github.com/heptiolabs/gangway/issues/131