### PR TITLE
fix:  Logout button href not using the basepath

### DIFF
--- a/templates/commandline.tmpl
+++ b/templates/commandline.tmpl
@@ -22,7 +22,7 @@
         <nav class="light-blue blue" role="navigation">
             <div class="nav-wrapper container"><a id="logo-container" href="#" class="brand-logo">gangway</a>
             <ul class="right hide-on-med-and-down">
-                <li><a href="/logout">Logout</a></li>
+                <li><a href="{{ .HTTPPath }}/logout">Logout</a></li>
             </ul>
 
             <ul id="nav-mobile" class="side-nav">


### PR DESCRIPTION
This is the fix for issue https://github.com/heptiolabs/gangway/issues/150

---

I've confirmed that it works for me by:

1. Creating a docker image with the fix called `MY_PRIVATE_DOCKER_REGISTRY/gangway:test`
2. Using the Gangway helm chart found [here](https://github.com/helm/charts/tree/master/stable/gangway)
3. In the values.yaml file, 
    * Set `image.repository` to  `MY_PRIVATE_DOCKER_REGISTRY/gangway`
    * Set `image.tag` to `test`
    * Set `gangway.httpPath` to `/gangway`

e.g.

```
# values.yaml

    image:
      repository: MY_PRIVATE_DOCKER_REGISTRY/gangway
      tag: test

    gangway:
      httpPath: /gangway

```

4. Run `helm install` (I'm using helm v2.15.2 and kubectl v1.16.3)
5. Signing in to Gangway and then clicking the logout button