### PR TITLE
[Bugfix] Fixed CVEs in gangway image by migrating to Debian base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12
+FROM golang:1.14.2-stretch
 WORKDIR /go/src/github.com/heptiolabs/gangway
 
 RUN go get github.com/golang/dep/cmd/dep
@@ -13,7 +13,7 @@ RUN esc -o cmd/gangway/bindata.go templates/
 
 RUN CGO_ENABLED=0 GOOS=linux go install -ldflags="-w -s" -v github.com/heptiolabs/gangway/...
 
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
+FROM debian:9.12-slim
+RUN apt-get update && apt-get install -y ca-certificates
 USER 1001:1001
 COPY --from=0 /go/bin/gangway /bin/gangway


### PR DESCRIPTION
- Comple gangway based on go1.13-stretch
- Build gangway image on top of amd64/debian latest image
- The new built gangway image was tested

Fixe #158 
Signed-off-by: FAN ZHANG <fanz@vmware.com>