### PR TITLE
Add security context to gangway deployment

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ If using the example YAML, create a secret to hold this value with the following
 
 ```
 kubectl -n gangway create secret generic gangway-key \
-  --from-literal=sesssionkey=$(openssl rand -base64 32)
+  --from-literal=sessionkey=$(openssl rand -base64 32)
 ```
 
 ## Path Prefix
@@ -55,7 +55,7 @@ kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.4.1/
 Apply the following config to create the staging and production `ClusterIssuer` making sure to update the `email` field below with your email address:
 
 ```sh
-cat <<EOF | kubectl create -f - 
+cat <<EOF | kubectl create -f -
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: ClusterIssuer
 metadata:
@@ -102,7 +102,7 @@ Get the hostname of the ELB that Kubernetes created for the contour service:
 kubectl get svc -n heptio-contour contour -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
 ```
 
-Create a wildcard CNAME record that aliases the domain under your control to the hostname of the ELB obtained above. 
+Create a wildcard CNAME record that aliases the domain under your control to the hostname of the ELB obtained above.
 
 For instance, if you own `example.com`, create a CNAME record for `*.example.com`, so that you can access gangway at `https://gangway.example.com`.
 
@@ -131,7 +131,7 @@ Create the gangway cookies that are used to encrypt gangway cookies:
 
 ```sh
 kubectl -n gangway create secret generic gangway-key \
-  --from-literal=sesssionkey=$(openssl rand -base64 32)
+  --from-literal=sessionkey=$(openssl rand -base64 32)
 ```
 
 ### Validate Certs

--- a/docs/yaml/03-deployment.yaml
+++ b/docs/yaml/03-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: gangway

--- a/docs/yaml/03-deployment.yaml
+++ b/docs/yaml/03-deployment.yaml
@@ -57,6 +57,10 @@ spec:
           timeoutSeconds: 1
           periodSeconds: 10
           failureThreshold: 3
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
       volumes:
       - name: gangway
         configMap:

--- a/docs/yaml/03-deployment.yaml
+++ b/docs/yaml/03-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: gangway
-        image: gcr.io/heptio-images/gangway:v3.1.0
+        image: gcr.io/heptio-images/gangway:v3.2.0
         imagePullPolicy: Always
         command: ["gangway", "-config", "/gangway/gangway.yaml"]
         env:

--- a/docs/yaml/03-deployment.yaml
+++ b/docs/yaml/03-deployment.yaml
@@ -18,46 +18,46 @@ spec:
         revision: "1"
     spec:
       containers:
+      - name: gangway
+        image: gcr.io/heptio-images/gangway:v3.1.0
+        imagePullPolicy: Always
+        command: ["gangway", "-config", "/gangway/gangway.yaml"]
+        env:
+        - name: GANGWAY_SESSION_SECURITY_KEY
+          valueFrom:
+            secretKeyRef:
+              name: gangway-key
+              key: sesssionkey
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "200m"
+            memory: "512Mi"
+        volumeMounts:
         - name: gangway
-          image: gcr.io/heptio-images/gangway:v3.1.0
-          imagePullPolicy: Always
-          command: ["gangway", "-config", "/gangway/gangway.yaml"]
-          env:
-            - name: GANGWAY_SESSION_SECURITY_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: gangway-key
-                  key: sesssionkey
-          ports:
-            - name: http
-              containerPort: 8080
-              protocol: TCP
-          resources:
-            requests:
-              cpu: "100m"
-              memory: "128Mi"
-            limits:
-              cpu: "200m"
-              memory: "512Mi"
-          volumeMounts:
-            - name: gangway
-              mountPath: /gangway/
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 8080
-            initialDelaySeconds: 20
-            timeoutSeconds: 1
-            periodSeconds: 60
-            failureThreshold: 3
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 8080
-            timeoutSeconds: 1
-            periodSeconds: 10
-            failureThreshold: 3
+          mountPath: /gangway/
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 20
+          timeoutSeconds: 1
+          periodSeconds: 60
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          timeoutSeconds: 1
+          periodSeconds: 10
+          failureThreshold: 3
       volumes:
-        - name: gangway
-          configMap:
-            name: gangway
+      - name: gangway
+        configMap:
+          name: gangway

--- a/docs/yaml/03-deployment.yaml
+++ b/docs/yaml/03-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: gangway-key
-              key: sesssionkey
+              key: sessionkey
         ports:
         - name: http
           containerPort: 8080

--- a/docs/yaml/05-ingress.yaml
+++ b/docs/yaml/05-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: gangway


### PR DESCRIPTION
**Note**: Please see the changes commit by commit to see flow of changes.

- This PR adds security context to the deployment pods, which enforces the app to run as non-root.
- This PR also changes the `apiVersion` to `apps/v1`.