### PR TITLE
fix deprecated args on staticcheck command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ test:
 
 staticcheck:
 	@go get honnef.co/go/tools/cmd/staticcheck
-	staticcheck -unused.whole-program $(PKGS)
+	staticcheck $(PKGS)
 
 misspell:
 	@go get github.com/client9/misspell/cmd/misspell


### PR DESCRIPTION
Signed-off-by: Steve Sloka <slokas@vmware.com>