### PR TITLE
Set TLSv1.2 as minimum version TLS protocol

### DIFF
--- a/cmd/gangway/main.go
+++ b/cmd/gangway/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"net/http"
@@ -92,6 +93,24 @@ func main() {
 		Addr:         bindAddr,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
+	}
+
+	if cfg.ServeTLS {
+		// update http server with TLS config
+		httpServer.TLSConfig = &tls.Config{
+			CipherSuites: []uint16{
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+				tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+			},
+			PreferServerCipherSuites: true,
+			MinVersion:               tls.VersionTLS12,
+		}
 	}
 
 	// start up the http server

--- a/internal/config/transport.go
+++ b/internal/config/transport.go
@@ -61,7 +61,9 @@ func NewTransportConfig(trustedCAPath string) *TransportConfig {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		TLSClientConfig: &tls.Config{
-			RootCAs: rootCAs,
+			RootCAs:                  rootCAs,
+			PreferServerCipherSuites: true,
+			MinVersion:               tls.VersionTLS12,
 		},
 	}
 


### PR DESCRIPTION
Stop to use insecure TLS version protocols and set TLSv1.2 as minimum.
TLSv1.1 and older were already deprecated and it should be dropped.